### PR TITLE
Add course creation endpoint and initialize schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,3 +7,6 @@
 - La till `docker-compose.yml` för att köra Postgres, backend och frontend i utvecklingsläge.
 - Uppdaterade README med instruktioner samt skapade `.env.example`-filer för frontend och backend.
 - La till `.gitignore` och dokumenterade förändringar i denna fil.
+- Implementerade `POST /courses` i backend som skapar kurs med UUID, validerar indata och säkerställer kurs-tabellen i Postgres.
+
+**Nästa steg:** Bygga frontendflödet för att skapa en kurs (dialog + state-initiering enligt US-M1-01) och börja modellera modul- och lektionsstruktur (US-M1-02).

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "backend",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "dotenv": "^17.2.2",
         "express": "^5.1.0",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import type { Request, Response } from 'express';
 import dotenv from 'dotenv';
 import { Pool } from 'pg';
+import { randomUUID } from 'crypto';
 
 dotenv.config();
 
@@ -37,6 +38,85 @@ app.get('/health', async (_req: Request, res: Response) => {
   }
 });
 
-app.listen(Number(port), () => {
-  console.log(`Backend listening on port ${port}`);
-});
+type CreateCourseBody = {
+  title?: unknown;
+  language?: unknown;
+};
+
+app.post(
+  '/courses',
+  async (req: Request<unknown, unknown, CreateCourseBody>, res: Response) => {
+    if (!pool) {
+      res.status(503).json({ message: 'Database is not configured' });
+      return;
+    }
+
+    const title = typeof req.body.title === 'string' ? req.body.title.trim() : '';
+    const language =
+      typeof req.body.language === 'string' ? req.body.language.trim() : '';
+
+    if (!title) {
+      res.status(400).json({ message: 'title is required' });
+      return;
+    }
+
+    if (!language) {
+      res.status(400).json({ message: 'language is required' });
+      return;
+    }
+
+    const courseId = randomUUID();
+
+    try {
+      const { rows } = await pool.query(
+        `INSERT INTO courses (course_id, title, language)
+         VALUES ($1, $2, $3)
+         RETURNING course_id, title, language, created_at, updated_at`,
+        [courseId, title, language]
+      );
+
+      const course = rows[0];
+
+      res.status(201).json({
+        courseId: course.course_id,
+        title: course.title,
+        language: course.language,
+        createdAt: course.created_at,
+        updatedAt: course.updated_at,
+      });
+    } catch (error) {
+      console.error('Failed to create course', error);
+      res.status(500).json({ message: 'Failed to create course' });
+    }
+  }
+);
+
+async function ensureSchema(database: Pool) {
+  await database.query(`
+    CREATE TABLE IF NOT EXISTS courses (
+      course_id uuid PRIMARY KEY,
+      title text NOT NULL,
+      language text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+}
+
+async function start() {
+  if (pool) {
+    try {
+      await ensureSchema(pool);
+    } catch (error) {
+      console.error('Failed to ensure database schema', error);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  app.listen(Number(port), () => {
+    console.log(`Backend listening on port ${port}`);
+  });
+}
+
+void start();


### PR DESCRIPTION
## Summary
- add a POST /courses endpoint that validates payloads and persists courses with UUIDs
- ensure the courses table exists on startup so database deployments bootstrap automatically
- document the update and next steps in CHANGES.md

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd04d593ac8322ade9a5dc342a64fb