### PR TITLE
Implement frontend course creation flow and outline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,5 +13,6 @@
 
 - Byggde kursflöde i frontend med modal för att skapa kurser mot `POST /courses`, lokal kursstore och outline för moduler och lektioner.
 - Lade till möjlighet att skapa moduler och lektioner i UI samt visning av vald modul/lektion som grund för blockredigeraren.
+- Förbättrade kursstoren genom att nollställa till nytt tillstånd, stödja existerande moduler vid `setCourse` och automatiskt välja första modul/lektion om de finns.
 
 **Nästa steg:** Knyta modul- och lektionshanteringen till backend (CRUD-endpoints + persistens) och utöka outline-komponenten med ordning/drag-dropp enligt US-M1-02.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,4 +9,9 @@
 - La till `.gitignore` och dokumenterade förändringar i denna fil.
 - Implementerade `POST /courses` i backend som skapar kurs med UUID, validerar indata och säkerställer kurs-tabellen i Postgres.
 
-**Nästa steg:** Bygga frontendflödet för att skapa en kurs (dialog + state-initiering enligt US-M1-01) och börja modellera modul- och lektionsstruktur (US-M1-02).
+## 2025-09-20
+
+- Byggde kursflöde i frontend med modal för att skapa kurser mot `POST /courses`, lokal kursstore och outline för moduler och lektioner.
+- Lade till möjlighet att skapa moduler och lektioner i UI samt visning av vald modul/lektion som grund för blockredigeraren.
+
+**Nästa steg:** Knyta modul- och lektionshanteringen till backend (CRUD-endpoints + persistens) och utöka outline-komponenten med ordning/drag-dropp enligt US-M1-02.

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -1,1 +1,2 @@
-// place files you want to import through the `$lib` alias in this folder.
+export * from './stores/course-store';
+export * from './types/course';

--- a/frontend/src/lib/stores/course-store.ts
+++ b/frontend/src/lib/stores/course-store.ts
@@ -7,11 +7,13 @@ export type CourseStoreState = {
   selectedLessonId: string | null;
 };
 
-const initialState: CourseStoreState = {
-  course: null,
-  selectedModuleId: null,
-  selectedLessonId: null,
-};
+function createInitialState(): CourseStoreState {
+  return {
+    course: null,
+    selectedModuleId: null,
+    selectedLessonId: null,
+  };
+}
 
 function createModule(title: string, position: number): Module {
   return {
@@ -31,21 +33,23 @@ function createLesson(title: string, position: number): Lesson {
 }
 
 function createCourseStore() {
-  const { subscribe, update, set } = writable(initialState);
+  const { subscribe, update, set } = writable(createInitialState());
 
   return {
     subscribe,
     reset() {
-      set(initialState);
+      set(createInitialState());
     },
-    setCourse(course: CourseSummary) {
+    setCourse(course: Course | CourseSummary) {
+      const modules = 'modules' in course ? course.modules : [];
+
       set({
         course: {
           ...course,
-          modules: [],
+          modules,
         },
-        selectedLessonId: null,
-        selectedModuleId: null,
+        selectedModuleId: modules.at(0)?.moduleId ?? null,
+        selectedLessonId: modules.at(0)?.lessons.at(0)?.lessonId ?? null,
       });
     },
     addModule(title: string) {

--- a/frontend/src/lib/stores/course-store.ts
+++ b/frontend/src/lib/stores/course-store.ts
@@ -1,0 +1,130 @@
+import { writable } from 'svelte/store';
+import type { Course, CourseSummary, Lesson, Module } from '$lib/types/course';
+
+export type CourseStoreState = {
+  course: Course | null;
+  selectedModuleId: string | null;
+  selectedLessonId: string | null;
+};
+
+const initialState: CourseStoreState = {
+  course: null,
+  selectedModuleId: null,
+  selectedLessonId: null,
+};
+
+function createModule(title: string, position: number): Module {
+  return {
+    moduleId: crypto.randomUUID(),
+    title,
+    position,
+    lessons: [],
+  };
+}
+
+function createLesson(title: string, position: number): Lesson {
+  return {
+    lessonId: crypto.randomUUID(),
+    title,
+    position,
+  };
+}
+
+function createCourseStore() {
+  const { subscribe, update, set } = writable(initialState);
+
+  return {
+    subscribe,
+    reset() {
+      set(initialState);
+    },
+    setCourse(course: CourseSummary) {
+      set({
+        course: {
+          ...course,
+          modules: [],
+        },
+        selectedLessonId: null,
+        selectedModuleId: null,
+      });
+    },
+    addModule(title: string) {
+      update((state) => {
+        if (!state.course) {
+          return state;
+        }
+
+        const module = createModule(title, state.course.modules.length);
+        return {
+          ...state,
+          course: {
+            ...state.course,
+            modules: [...state.course.modules, module],
+          },
+          selectedModuleId: module.moduleId,
+          selectedLessonId: null,
+        };
+      });
+    },
+    addLesson(moduleId: string, title: string) {
+      update((state) => {
+        if (!state.course) {
+          return state;
+        }
+
+        const modules = state.course.modules.map((module) => {
+          if (module.moduleId !== moduleId) {
+            return module;
+          }
+
+          const lesson = createLesson(title, module.lessons.length);
+          return {
+            ...module,
+            lessons: [...module.lessons, lesson],
+          };
+        });
+
+        const selectedModule = modules.find((module) => module.moduleId === moduleId);
+        const selectedLessonId = selectedModule?.lessons.at(-1)?.lessonId ?? null;
+
+        return {
+          ...state,
+          course: {
+            ...state.course,
+            modules,
+          },
+          selectedModuleId: moduleId,
+          selectedLessonId,
+        };
+      });
+    },
+    selectModule(moduleId: string) {
+      update((state) => {
+        if (!state.course) {
+          return state;
+        }
+
+        return {
+          ...state,
+          selectedModuleId: moduleId,
+          selectedLessonId: null,
+        };
+      });
+    },
+    selectLesson(moduleId: string, lessonId: string) {
+      update((state) => {
+        if (!state.course) {
+          return state;
+        }
+
+        return {
+          ...state,
+          selectedModuleId: moduleId,
+          selectedLessonId: lessonId,
+        };
+      });
+    },
+  };
+}
+
+export const courseStore = createCourseStore();

--- a/frontend/src/lib/types/course.ts
+++ b/frontend/src/lib/types/course.ts
@@ -1,0 +1,24 @@
+export type CourseSummary = {
+  courseId: string;
+  title: string;
+  language: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Lesson = {
+  lessonId: string;
+  title: string;
+  position: number;
+};
+
+export type Module = {
+  moduleId: string;
+  title: string;
+  position: number;
+  lessons: Lesson[];
+};
+
+export type Course = CourseSummary & {
+  modules: Module[];
+};

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,97 +1,850 @@
 <script lang="ts">
   import { env } from '$env/dynamic/public';
   import { onMount } from 'svelte';
+  import { courseStore, type CourseStoreState, type CourseSummary } from '$lib';
 
   const backendUrl = env.PUBLIC_BACKEND_URL || 'http://localhost:3001';
 
-  let status: 'idle' | 'loading' | 'success' | 'error' = 'idle';
-  let message = '';
+  type CreateCourseForm = {
+    title: string;
+    language: string;
+  };
+
+  const languageOptions = [
+    { value: 'sv', label: 'Svenska' },
+    { value: 'en', label: 'English' },
+  ];
+
+  let backendStatus: 'idle' | 'loading' | 'success' | 'error' = 'idle';
+  let backendMessage = '';
+
+  let showCreateCourseDialog = false;
+  let createCourseForm: CreateCourseForm = { title: '', language: 'sv' };
+  let createCourseErrors: { title?: string; language?: string; general?: string } = {};
+  let isCreatingCourse = false;
+
+  let newModuleTitle = '';
+  let lessonDrafts: Record<string, string> = {};
+
+  let courseState: CourseStoreState;
+  $: courseState = $courseStore;
+  $: currentCourse = courseState.course;
+  $: selectedModule =
+    currentCourse?.modules.find((module) => module.moduleId === courseState.selectedModuleId) ??
+    null;
+  $: selectedLesson =
+    selectedModule?.lessons.find((lesson) => lesson.lessonId === courseState.selectedLessonId) ??
+    null;
 
   onMount(async () => {
-    status = 'loading';
+    backendStatus = 'loading';
 
     try {
       const response = await fetch(`${backendUrl}/health`);
+      const data = (await response.json().catch(() => null)) as
+        | { status?: string; database?: string; timestamp?: string }
+        | null;
+
       if (!response.ok) {
-        throw new Error(`Unexpected status ${response.status}`);
+        throw new Error(`Backend svarade med status ${response.status}`);
       }
-      const data = await response.json();
-      status = 'success';
-      message = `Backend svarar: ${JSON.stringify(data)}`;
+
+      backendStatus = 'success';
+      backendMessage =
+        data?.database === 'connected'
+          ? 'Backend ansluten och databas kontaktbar.'
+          : 'Backend svarade.';
     } catch (error) {
-      status = 'error';
-      message = `Kunde inte nå backend: ${(error as Error).message}`;
+      backendStatus = 'error';
+      backendMessage = (error as Error).message;
     }
   });
+
+  function openCreateCourseDialog() {
+    createCourseForm = { title: '', language: 'sv' };
+    createCourseErrors = {};
+    showCreateCourseDialog = true;
+    isCreatingCourse = false;
+  }
+
+  function closeCreateCourseDialog() {
+    if (isCreatingCourse) {
+      return;
+    }
+
+    showCreateCourseDialog = false;
+  }
+
+  function getLanguageLabel(value: string) {
+    return languageOptions.find((option) => option.value === value)?.label ?? value;
+  }
+
+  function validateCreateCourseForm() {
+    const errors: typeof createCourseErrors = {};
+
+    if (!createCourseForm.title.trim()) {
+      errors.title = 'Ange en titel.';
+    }
+
+    if (!createCourseForm.language.trim()) {
+      errors.language = 'Ange ett språk.';
+    }
+
+    createCourseErrors = errors;
+    return Object.keys(errors).length === 0;
+  }
+
+  function parseCoursePayload(payload: unknown): CourseSummary {
+    if (!payload || typeof payload !== 'object') {
+      throw new Error('Oväntat svar från servern.');
+    }
+
+    const { courseId, title, language, createdAt, updatedAt } = payload as Record<string, unknown>;
+
+    if (
+      typeof courseId !== 'string' ||
+      typeof title !== 'string' ||
+      typeof language !== 'string' ||
+      typeof createdAt !== 'string' ||
+      typeof updatedAt !== 'string'
+    ) {
+      throw new Error('Svar saknar förväntade fält.');
+    }
+
+    return { courseId, title, language, createdAt, updatedAt };
+  }
+
+  async function handleCreateCourseSubmit(event: SubmitEvent) {
+    event.preventDefault();
+
+    if (!validateCreateCourseForm()) {
+      return;
+    }
+
+    isCreatingCourse = true;
+    createCourseErrors = {};
+
+    try {
+      const response = await fetch(`${backendUrl}/courses`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: createCourseForm.title.trim(),
+          language: createCourseForm.language.trim(),
+        }),
+      });
+
+      const text = await response.text();
+      const payload = text ? (JSON.parse(text) as unknown) : null;
+
+      if (!response.ok) {
+        const message =
+          payload && typeof payload === 'object' && 'message' in payload
+            ? String((payload as { message?: unknown }).message ?? 'Kunde inte skapa kursen.')
+            : `Kunde inte skapa kursen (status ${response.status}).`;
+        throw new Error(message);
+      }
+
+      const course = parseCoursePayload(payload);
+      courseStore.setCourse(course);
+      showCreateCourseDialog = false;
+      newModuleTitle = '';
+      lessonDrafts = {};
+    } catch (error) {
+      createCourseErrors = { general: (error as Error).message };
+    } finally {
+      isCreatingCourse = false;
+    }
+  }
+
+  function handleDialogKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      closeCreateCourseDialog();
+    }
+  }
+
+  function handleGlobalKeydown(event: KeyboardEvent) {
+    if (!showCreateCourseDialog) {
+      return;
+    }
+
+    handleDialogKeydown(event);
+  }
+
+  function handleAddModule() {
+    const title = newModuleTitle.trim();
+    if (!title) {
+      return;
+    }
+
+    courseStore.addModule(title);
+    newModuleTitle = '';
+  }
+
+  function handleAddLesson(moduleId: string) {
+    const title = (lessonDrafts[moduleId] ?? '').trim();
+    if (!title) {
+      return;
+    }
+
+    courseStore.addLesson(moduleId, title);
+    lessonDrafts = { ...lessonDrafts, [moduleId]: '' };
+  }
+
+  function handleModuleDraftChange(moduleId: string, value: string) {
+    lessonDrafts = { ...lessonDrafts, [moduleId]: value };
+  }
 </script>
 
 <svelte:head>
   <title>Course Builder</title>
 </svelte:head>
 
+<svelte:window on:keydown={handleGlobalKeydown} />
+
 <main>
-  <h1>Course Builder</h1>
-  <p>
-    Detta reposkelett använder <strong>SvelteKit</strong> i frontend, en
-    <strong>Node.js</strong>-backend och <strong>Postgres</strong> som databas.
-  </p>
+  <header class="page-header">
+    <div>
+      <h1>Course Builder</h1>
+      <p class="lead">Skapa kursstrukturer med moduler, lektioner och block-baserat innehåll.</p>
+    </div>
 
-  <section>
-    <h2>Status för backend</h2>
-    {#if status === 'idle' || status === 'loading'}
-      <p>Kontrollerar anslutningen mot backend på <code>{backendUrl}</code>…</p>
-    {:else if status === 'success'}
-      <p class="success">{message}</p>
-    {:else}
-      <p class="error">{message}</p>
-    {/if}
-  </section>
+    <div class="header-actions">
+      <button class="primary" type="button" on:click={openCreateCourseDialog}>
+        Ny kurs
+      </button>
+      <div class="backend-status" data-status={backendStatus}>
+        {#if backendStatus === 'loading'}
+          <span class="dot" aria-hidden="true"></span>
+          <span>Kontrollerar backend…</span>
+        {:else if backendStatus === 'success'}
+          <span class="dot" aria-hidden="true"></span>
+          <span>{backendMessage}</span>
+        {:else if backendStatus === 'error'}
+          <span class="dot" aria-hidden="true"></span>
+          <span>Backend-fel: {backendMessage}</span>
+        {:else}
+          <span class="dot" aria-hidden="true"></span>
+          <span>Backend-status okänd.</span>
+        {/if}
+      </div>
+    </div>
+  </header>
 
-  <section>
-    <h2>Nästa steg</h2>
-    <ol>
-      <li>Installera beroenden i <code>frontend</code> och <code>backend</code>.</li>
-      <li>
-        Använd <code>docker compose up</code> för att starta Postgres, backend och frontend i
-        utvecklingsläge.
-      </li>
-      <li>Bygg vidare på skelettet med din applikationslogik.</li>
-    </ol>
-  </section>
+  {#if currentCourse}
+    <section class="workspace">
+      <aside class="outline" aria-label="Kursstruktur">
+        <div class="outline-header">
+          <h2>{currentCourse.title}</h2>
+          <p class="muted">Språk: {getLanguageLabel(currentCourse.language)}</p>
+        </div>
+
+        <div class="module-list">
+          {#if currentCourse.modules.length === 0}
+            <p class="empty">Inga moduler ännu. Lägg till din första modul nedan.</p>
+          {/if}
+
+          {#each currentCourse.modules as module, index}
+            <section class="module" class:active={module.moduleId === courseState.selectedModuleId}>
+              <header>
+                <button
+                  type="button"
+                  class="module-trigger"
+                  on:click={() => courseStore.selectModule(module.moduleId)}
+                >
+                  <span class="module-index">Modul {index + 1}</span>
+                  <span class="module-title">{module.title}</span>
+                </button>
+              </header>
+
+              <div class="lessons">
+                {#if module.lessons.length === 0}
+                  <p class="empty">Inga lektioner ännu.</p>
+                {:else}
+                  <ul>
+                    {#each module.lessons as lesson, lessonIndex}
+                      <li>
+                        <button
+                          type="button"
+                          class:active={
+                            lesson.lessonId === courseState.selectedLessonId &&
+                            module.moduleId === courseState.selectedModuleId
+                          }
+                          on:click={() => courseStore.selectLesson(module.moduleId, lesson.lessonId)}
+                        >
+                          <span class="lesson-index">Lektion {lessonIndex + 1}</span>
+                          <span class="lesson-title">{lesson.title}</span>
+                        </button>
+                      </li>
+                    {/each}
+                  </ul>
+                {/if}
+
+                <form
+                  class="lesson-form"
+                  on:submit|preventDefault={() => handleAddLesson(module.moduleId)}
+                >
+                  <label class="sr-only" for={`lesson-${module.moduleId}`}>
+                    Lektionstitel för {module.title}
+                  </label>
+                  <input
+                    id={`lesson-${module.moduleId}`}
+                    name={`lesson-${module.moduleId}`}
+                    type="text"
+                    placeholder="Lägg till lektion"
+                    value={lessonDrafts[module.moduleId] ?? ''}
+                    on:input={(event) =>
+                      handleModuleDraftChange(module.moduleId, (event.target as HTMLInputElement).value)}
+                  />
+                  <button type="submit">Spara</button>
+                </form>
+              </div>
+            </section>
+          {/each}
+        </div>
+
+        <form class="module-form" on:submit|preventDefault={handleAddModule}>
+          <label class="sr-only" for="module-title">Modulstitel</label>
+          <input
+            id="module-title"
+            name="module-title"
+            type="text"
+            placeholder="Lägg till modul"
+            bind:value={newModuleTitle}
+          />
+          <button type="submit">Lägg till modul</button>
+        </form>
+      </aside>
+
+      <section class="details" aria-live="polite">
+        {#if selectedLesson}
+          <div class="detail-card">
+            <h2>{selectedLesson.title}</h2>
+            <p class="muted">
+              Tillhör modul: {selectedModule?.title ?? 'Okänd modul'} • Position: {selectedLesson.position + 1}
+            </p>
+            <p>
+              Blockredigering kommer här. Nästa steg är att koppla block och autosparning mot backend.
+            </p>
+          </div>
+        {:else if selectedModule}
+          <div class="detail-card">
+            <h2>{selectedModule.title}</h2>
+            <p class="muted">Position: {selectedModule.position + 1}</p>
+            <p>Välj en lektion eller skapa en ny för att börja lägga till block.</p>
+          </div>
+        {:else}
+          <div class="detail-card">
+            <h2>Välj modul eller lektion</h2>
+            <p>Markera en modul eller lektion i vänsterspalten för att se detaljer.</p>
+          </div>
+        {/if}
+      </section>
+    </section>
+  {:else}
+    <section class="empty-state">
+      <h2>Skapa din första kurs</h2>
+      <p>
+        Starta genom att skapa en kurs. När kursen har skapats kan du lägga till moduler och lektioner i
+        kursstrukturen.
+      </p>
+      <button class="primary" type="button" on:click={openCreateCourseDialog}>
+        Starta ny kurs
+      </button>
+    </section>
+  {/if}
 </main>
 
+{#if showCreateCourseDialog}
+  <div class="modal-root">
+    <div class="modal-scrim" aria-hidden="true" on:click={closeCreateCourseDialog}></div>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="create-course-title">
+      <form class="modal-content" on:submit={handleCreateCourseSubmit}>
+        <div class="modal-header">
+          <h2 id="create-course-title">Ny kurs</h2>
+        </div>
+
+        <div class="modal-body">
+          {#if createCourseErrors.general}
+            <p class="alert">{createCourseErrors.general}</p>
+          {/if}
+
+          <label for="course-title">Titel</label>
+          <input
+            id="course-title"
+            name="title"
+            type="text"
+            placeholder="Till exempel: Introduktion till AI"
+            bind:value={createCourseForm.title}
+            class:error={Boolean(createCourseErrors.title)}
+            aria-invalid={Boolean(createCourseErrors.title)}
+          />
+          {#if createCourseErrors.title}
+            <p class="field-error">{createCourseErrors.title}</p>
+          {/if}
+
+          <label for="course-language">Språk</label>
+          <select
+            id="course-language"
+            name="language"
+            bind:value={createCourseForm.language}
+            class:error={Boolean(createCourseErrors.language)}
+            aria-invalid={Boolean(createCourseErrors.language)}
+          >
+            {#each languageOptions as option}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+          {#if createCourseErrors.language}
+            <p class="field-error">{createCourseErrors.language}</p>
+          {/if}
+        </div>
+
+        <div class="modal-footer">
+          <button type="button" class="ghost" on:click={closeCreateCourseDialog} disabled={isCreatingCourse}>
+            Avbryt
+          </button>
+          <button type="submit" class="primary" disabled={isCreatingCourse}>
+            {#if isCreatingCourse}
+              Skapar…
+            {:else}
+              Skapa kurs
+            {/if}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}
+
 <style>
+  :global(body) {
+    background: #f5f7fb;
+    color: #1f2933;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
   main {
-    max-width: 60rem;
+    max-width: 1100px;
     margin: 0 auto;
-    padding: 2rem;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 2.5rem 1.5rem 4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
   }
 
-  h1 {
-    margin-bottom: 1rem;
+  .page-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
   }
 
-  section {
-    margin-top: 2rem;
+  .page-header h1 {
+    margin: 0;
+    font-size: 2.25rem;
+    font-weight: 700;
+  }
+
+  .lead {
+    margin: 0.25rem 0 0;
+    color: #52606d;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .backend-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: #e4e7ec;
+    font-size: 0.9rem;
+    color: #364152;
+  }
+
+  .backend-status[data-status='loading'] {
+    background: #f4ebff;
+    color: #6941c6;
+  }
+
+  .backend-status[data-status='success'] {
+    background: #dcfce7;
+    color: #047857;
+  }
+
+  .backend-status[data-status='error'] {
+    background: #fee2e2;
+    color: #b91c1c;
+  }
+
+  .backend-status .dot {
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 999px;
+    background: currentColor;
+  }
+
+  .primary {
+    background: #2563eb;
+    color: #fff;
+    border: none;
+    border-radius: 0.65rem;
+    padding: 0.65rem 1.25rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease-in-out;
+  }
+
+  .primary:disabled {
+    opacity: 0.7;
+    cursor: default;
+  }
+
+  .primary:not(:disabled):hover,
+  .primary:not(:disabled):focus-visible {
+    background: #1d4ed8;
+  }
+
+  .ghost {
+    background: transparent;
+    color: #364152;
+    border: 1px solid #d2d6dc;
+    border-radius: 0.65rem;
+    padding: 0.65rem 1.1rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s ease-in-out, color 0.2s ease-in-out;
+  }
+
+  .ghost:hover,
+  .ghost:focus-visible {
+    background: #f1f5f9;
+    color: #1f2937;
+  }
+
+  .workspace {
+    display: grid;
+    grid-template-columns: minmax(280px, 360px) 1fr;
+    gap: 1.75rem;
+  }
+
+  .outline {
+    background: #fff;
+    border-radius: 1rem;
     padding: 1.5rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .outline-header h2 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+
+  .muted {
+    color: #667085;
+    font-size: 0.95rem;
+    margin: 0.25rem 0 0;
+  }
+
+  .module-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .module {
+    border: 1px solid #e5e7eb;
     border-radius: 0.75rem;
-    background: #f8f9fb;
-    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+    background: #f9fafb;
+    overflow: hidden;
   }
 
-  code {
-    font-size: 0.95em;
-    background: rgba(15, 23, 42, 0.08);
-    padding: 0.1rem 0.35rem;
-    border-radius: 0.35rem;
+  .module.active {
+    border-color: #2563eb;
+    background: #eef2ff;
   }
 
-  .success {
-    color: #1a7f37;
+  .module header {
+    background: rgba(37, 99, 235, 0.08);
+    padding: 0.75rem 1rem;
   }
 
-  .error {
-    color: #d32f2f;
+  .module.active header {
+    background: rgba(37, 99, 235, 0.16);
+  }
+
+  .module-trigger {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+    width: 100%;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    text-align: left;
+  }
+
+  .module-index {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #475467;
+  }
+
+  .module-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #1d2939;
+  }
+
+  .lessons {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .lessons ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .lessons button {
+    width: 100%;
+    border: none;
+    background: #fff;
+    border-radius: 0.65rem;
+    padding: 0.6rem 0.8rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.2rem;
+    cursor: pointer;
+    color: #334155;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
+    transition: box-shadow 0.2s ease-in-out, background 0.2s ease-in-out;
+  }
+
+  .lessons button.active {
+    background: rgba(37, 99, 235, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.4);
+    color: #1e3a8a;
+  }
+
+  .lesson-index {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #64748b;
+  }
+
+  .lesson-title {
+    font-size: 0.95rem;
+    font-weight: 500;
+  }
+
+  .lesson-form,
+  .module-form {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .lesson-form input,
+  .module-form input,
+  .modal-body input,
+  .modal-body select {
+    flex: 1;
+    border-radius: 0.65rem;
+    border: 1px solid #d2d6dc;
+    padding: 0.6rem 0.75rem;
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  }
+
+  .lesson-form input:focus,
+  .module-form input:focus,
+  .modal-body input:focus,
+  .modal-body select:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+  }
+
+  .lesson-form button,
+  .module-form button {
+    border-radius: 0.65rem;
+    border: none;
+    background: #475467;
+    color: #fff;
+    padding: 0.6rem 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s ease-in-out;
+  }
+
+  .lesson-form button:hover,
+  .module-form button:hover,
+  .lesson-form button:focus-visible,
+  .module-form button:focus-visible {
+    background: #1f2937;
+  }
+
+  .empty-state,
+  .detail-card {
+    background: #fff;
+    border-radius: 1rem;
+    padding: 2rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .details {
+    display: flex;
+    align-items: stretch;
+  }
+
+  .details .detail-card {
+    width: 100%;
+  }
+
+  .empty {
+    font-size: 0.9rem;
+    color: #94a3b8;
+  }
+
+  .modal-root {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    z-index: 50;
+  }
+
+  .modal-scrim {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+  }
+
+  .modal {
+    position: relative;
+    width: min(420px, calc(100% - 2rem));
+    background: #fff;
+    border-radius: 1rem;
+    box-shadow: 0 25px 50px -12px rgba(30, 41, 59, 0.35);
+    overflow: hidden;
+    z-index: 51;
+  }
+
+  .modal-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1.75rem;
+  }
+
+  .modal-header h2 {
+    margin: 0;
+    font-size: 1.5rem;
+  }
+
+  .modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .modal-body label {
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+
+  .modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+
+  .alert {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    background: #fef3c7;
+    color: #92400e;
+    border-radius: 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .field-error {
+    margin: -0.35rem 0 0;
+    font-size: 0.8rem;
+    color: #b91c1c;
+  }
+
+  input.error,
+  select.error {
+    border-color: #f87171;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 960px) {
+    .workspace {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .header-actions {
+      width: 100%;
+      justify-content: space-between;
+    }
+
+    .workspace {
+      gap: 1rem;
+    }
+
+    .page-header h1 {
+      font-size: 1.8rem;
+    }
+
+    .outline {
+      padding: 1.25rem;
+    }
+
+    .modal {
+      width: min(360px, calc(100% - 2rem));
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- add course data types and a Svelte store to manage modules and lessons in the frontend
- replace the landing page with a course creation dialog, outline workspace, and detail view
- update styling to support the new layout and show backend connectivity status

## Testing
- npm run check (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cd255107408322bd97ab54f40c1660