### PR TITLE
Add configurable CORS support to backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,5 +14,6 @@
 - Byggde kursflöde i frontend med modal för att skapa kurser mot `POST /courses`, lokal kursstore och outline för moduler och lektioner.
 - Lade till möjlighet att skapa moduler och lektioner i UI samt visning av vald modul/lektion som grund för blockredigeraren.
 - Förbättrade kursstoren genom att nollställa till nytt tillstånd, stödja existerande moduler vid `setCourse` och automatiskt välja första modul/lektion om de finns.
+- Aktiverade CORS-stöd i backend med konfigurerbara tillåtna ursprung för att möjliggöra kommunikation mellan frontend och API i utvecklingsmiljö.
 
-**Nästa steg:** Knyta modul- och lektionshanteringen till backend (CRUD-endpoints + persistens) och utöka outline-komponenten med ordning/drag-dropp enligt US-M1-02.
+**Nästa steg:** Konfigurera `CORS_ORIGINS` för relevanta miljöer och knyta modul- och lektionshanteringen till backend (CRUD-endpoints + persistens) samt utöka outline-komponenten med ordning/drag-dropp enligt US-M1-02.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@types/cors": "^2.8.19",
+        "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "pg": "^8.16.3"
@@ -484,6 +486,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
@@ -527,7 +538,6 @@
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.12.0"
@@ -690,6 +700,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/debug": {
@@ -1155,6 +1178,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1651,7 +1683,6 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@types/cors": "^2.8.19",
+    "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "pg": "^8.16.3"

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 import dotenv from 'dotenv';
+import cors from 'cors';
 import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
 
@@ -21,6 +22,29 @@ if (databaseUrl) {
 }
 
 const app = express();
+
+const corsOrigins = (process.env.CORS_ORIGINS ?? 'http://localhost:5173')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+
+      if (corsOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error(`Origin ${origin} is not allowed by CORS`));
+    },
+  })
+);
 app.use(express.json());
 
 app.get('/health', async (_req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- enable Express CORS middleware with configurable allowed origins so the frontend can call the backend without CORS errors
- document the change and next steps in the changelog

## Testing
- npm run lint (backend)


------
https://chatgpt.com/codex/tasks/task_e_68d0f260af348322b8a823b1eb0353a6