### PR TITLE
Add module persistence endpoints and hook frontend to backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ yarn-error.log*
 # Environment files
 .env
 .env.*
+!.env.example
+!backend/.env.example
+!frontend/.env.example
 backend/.env
 frontend/.env
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,3 +17,11 @@
 - Aktiverade CORS-stöd i backend med konfigurerbara tillåtna ursprung för att möjliggöra kommunikation mellan frontend och API i utvecklingsmiljö.
 
 **Nästa steg:** Konfigurera `CORS_ORIGINS` för relevanta miljöer och knyta modul- och lektionshanteringen till backend (CRUD-endpoints + persistens) samt utöka outline-komponenten med ordning/drag-dropp enligt US-M1-02.
+
+## 2025-09-21
+
+- La till miljövariabeln `CORS_ORIGINS` i backend (kod, `docker-compose` och `.env.example`) och dokumenterade hur den ska sättas.
+- Utökade backend med databastabeller för moduler och lektioner samt endpoints för att skapa dem med positionshantering och uppdatering av kursens tidsstämplar.
+- Kopplade frontendens modul- och lektionsformulär till backend, visade laddningsstatus och felmeddelanden samt sorterade lokala stores efter position.
+
+**Nästa steg:** Implementera `GET /courses/:id` som returnerar kurs med moduler/lektioner och ladda kursstrukturen från backend vid initiering. Förbered därefter stöd för omordning (drag & drop) och borttagning enligt US-M1-02.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Reposkelett för ett projekt med SvelteKit-frontend, Node.js-backend och Postgre
    cp backend/.env.example backend/.env
    cp frontend/.env.example frontend/.env
    ```
+   Uppdatera vid behov `CORS_ORIGINS` i `backend/.env` så att den listar alla frontend-ursprung som ska få
+   anropa API:t (komma-separerad lista, till exempel `http://localhost:5173,http://127.0.0.1:5173`).
 3. Starta hela stacken:
    ```bash
    docker compose up --build

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+# Backend environment configuration
+PORT=3001
+# Update with your local or hosted Postgres connection string
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/course_builder
+# Comma-separated list of allowed origins for CORS
+CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -47,6 +47,12 @@ app.use(
 );
 app.use(express.json());
 
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value
+  );
+}
+
 app.get('/health', async (_req: Request, res: Response) => {
   if (!pool) {
     res.json({ status: 'ok', database: 'not configured' });
@@ -115,12 +121,197 @@ app.post(
   }
 );
 
+type CreateModuleParams = {
+  courseId: string;
+};
+
+type CreateModuleBody = {
+  title?: unknown;
+};
+
+app.post(
+  '/courses/:courseId/modules',
+  async (req: Request<CreateModuleParams, unknown, CreateModuleBody>, res: Response) => {
+    if (!pool) {
+      res.status(503).json({ message: 'Database is not configured' });
+      return;
+    }
+
+    const courseId = req.params.courseId;
+    if (!isUuid(courseId)) {
+      res.status(400).json({ message: 'courseId must be a valid UUID' });
+      return;
+    }
+
+    const title = typeof req.body.title === 'string' ? req.body.title.trim() : '';
+    if (!title) {
+      res.status(400).json({ message: 'title is required' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const courseExists = await client.query('SELECT 1 FROM courses WHERE course_id = $1', [
+        courseId,
+      ]);
+
+      if (courseExists.rowCount === 0) {
+        await client.query('ROLLBACK');
+        res.status(404).json({ message: 'Course not found' });
+        return;
+      }
+
+      const positionResult = await client.query<{ position: string | number }>(
+        `SELECT COALESCE(MAX(position), -1) + 1 AS position FROM modules WHERE course_id = $1`,
+        [courseId]
+      );
+      const rawPosition = positionResult.rows[0]?.position ?? 0;
+      const position = Number(rawPosition);
+
+      const moduleId = randomUUID();
+
+      const insertedModule = await client.query(
+        `INSERT INTO modules (module_id, course_id, title, position)
+         VALUES ($1, $2, $3, $4)
+         RETURNING module_id, title, position`,
+        [moduleId, courseId, title, Number.isFinite(position) ? position : 0]
+      );
+
+      await client.query('UPDATE courses SET updated_at = NOW() WHERE course_id = $1', [courseId]);
+
+      await client.query('COMMIT');
+
+      const module = insertedModule.rows[0];
+      res.status(201).json({
+        moduleId: module.module_id,
+        title: module.title,
+        position: module.position,
+        lessons: [],
+      });
+    } catch (error) {
+      await client.query('ROLLBACK');
+      console.error('Failed to create module', error);
+      res.status(500).json({ message: 'Failed to create module' });
+    } finally {
+      client.release();
+    }
+  }
+);
+
+type CreateLessonParams = {
+  moduleId: string;
+};
+
+type CreateLessonBody = {
+  title?: unknown;
+};
+
+app.post(
+  '/modules/:moduleId/lessons',
+  async (req: Request<CreateLessonParams, unknown, CreateLessonBody>, res: Response) => {
+    if (!pool) {
+      res.status(503).json({ message: 'Database is not configured' });
+      return;
+    }
+
+    const moduleId = req.params.moduleId;
+    if (!isUuid(moduleId)) {
+      res.status(400).json({ message: 'moduleId must be a valid UUID' });
+      return;
+    }
+
+    const title = typeof req.body.title === 'string' ? req.body.title.trim() : '';
+    if (!title) {
+      res.status(400).json({ message: 'title is required' });
+      return;
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const moduleResult = await client.query<{ course_id: string }>(
+        'SELECT course_id FROM modules WHERE module_id = $1',
+        [moduleId]
+      );
+
+      const moduleRow = moduleResult.rows[0];
+
+      if (!moduleRow) {
+        await client.query('ROLLBACK');
+        res.status(404).json({ message: 'Module not found' });
+        return;
+      }
+
+      const positionResult = await client.query<{ position: string | number }>(
+        `SELECT COALESCE(MAX(position), -1) + 1 AS position FROM lessons WHERE module_id = $1`,
+        [moduleId]
+      );
+      const rawPosition = positionResult.rows[0]?.position ?? 0;
+      const position = Number(rawPosition);
+
+      const lessonId = randomUUID();
+
+      const insertedLesson = await client.query(
+        `INSERT INTO lessons (lesson_id, module_id, title, position)
+         VALUES ($1, $2, $3, $4)
+         RETURNING lesson_id, title, position`,
+        [lessonId, moduleId, title, Number.isFinite(position) ? position : 0]
+      );
+
+      await client.query('UPDATE modules SET updated_at = NOW() WHERE module_id = $1', [moduleId]);
+      await client.query('UPDATE courses SET updated_at = NOW() WHERE course_id = $1', [
+        moduleRow.course_id,
+      ]);
+
+      await client.query('COMMIT');
+
+      const lesson = insertedLesson.rows[0];
+      res.status(201).json({
+        lessonId: lesson.lesson_id,
+        title: lesson.title,
+        position: lesson.position,
+      });
+    } catch (error) {
+      await client.query('ROLLBACK');
+      console.error('Failed to create lesson', error);
+      res.status(500).json({ message: 'Failed to create lesson' });
+    } finally {
+      client.release();
+    }
+  }
+);
+
 async function ensureSchema(database: Pool) {
   await database.query(`
     CREATE TABLE IF NOT EXISTS courses (
       course_id uuid PRIMARY KEY,
       title text NOT NULL,
       language text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+
+  await database.query(`
+    CREATE TABLE IF NOT EXISTS modules (
+      module_id uuid PRIMARY KEY,
+      course_id uuid REFERENCES courses(course_id) ON DELETE CASCADE,
+      title text NOT NULL,
+      position int NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+
+  await database.query(`
+    CREATE TABLE IF NOT EXISTS lessons (
+      lesson_id uuid PRIMARY KEY,
+      module_id uuid REFERENCES modules(module_id) ON DELETE CASCADE,
+      title text NOT NULL,
+      position int NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
     );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       NODE_ENV: development
       PORT: 3001
       DATABASE_URL: postgresql://postgres:postgres@db:5432/course_builder
+      CORS_ORIGINS: http://localhost:5173
     volumes:
       - ./backend:/app
     depends_on:


### PR DESCRIPTION
## Summary
- add database tables and POST endpoints for modules and lessons including validation and course timestamp updates
- connect the Svelte course outline to backend mutations with parsing, loading states, and error feedback
- document and template the CORS_ORIGINS environment variable for local setups and docker compose

## Testing
- npm run lint --prefix backend
- npm run check --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d0f8bd2010832299349c1eee0a40dd