### PR TITLE
Add GET course endpoint and load course on frontend init

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,3 +25,11 @@
 - Kopplade frontendens modul- och lektionsformulär till backend, visade laddningsstatus och felmeddelanden samt sorterade lokala stores efter position.
 
 **Nästa steg:** Implementera `GET /courses/:id` som returnerar kurs med moduler/lektioner och ladda kursstrukturen från backend vid initiering. Förbered därefter stöd för omordning (drag & drop) och borttagning enligt US-M1-02.
+
+## 2025-09-22
+
+- Implementerade `GET /courses/:id` i backend som returnerar kurs med moduler och lektioner sorterade efter position samt hanterar saknade kurser.
+- Laddade kursstrukturen i frontend vid initiering genom att minnas senaste kurs-ID i `localStorage`, hämta kursdata från backend och visa status-/felmeddelanden.
+- Rensade och återställde lokalt tillstånd efter laddning och kurskapande för att förbereda kommande hantering av ordning och borttagning.
+
+**Nästa steg:** Bygg API- och UI-stöd för att omordna och ta bort moduler och lektioner (drag & drop + borttagningsflöden) så att kursstrukturen kan persisteras vid förändringar enligt US-M1-02.


### PR DESCRIPTION
## Summary
- add a backend GET `/courses/:id` endpoint that returns the full course structure with modules and lessons sorted by position
- remember the last selected course in local storage and load its structure from the backend when the UI mounts
- improve frontend state resets and status messaging so loading failures are surfaced and stale state is cleared

## Testing
- npm run lint (backend)
- npm run check (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68d11a2242888322be98db62c569a9aa