### PR TITLE
Convert course page to Svelte 5 runes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,3 +41,11 @@
 - Lagt till borttagningsflöden med bekräftelser, UI-feedback och uppdaterade stores för att hålla vald modul/lektion konsekvent efter ändringar.
 
 **Nästa steg:** Påbörja US-M1-03 genom att etablera backend-endpoint för block (`PATCH /lessons/:id/blocks`) och en första blocklista i frontend (text/heading/list) med autosparningsgrund.
+
+## 2025-09-24
+
+- Konverterade frontendens kursvy till Svelte 5 runes-läge, ersatte den tidigare reaktiviteten med `$state`/`$effect` och uppdaterade händelsebindningar till den nya attributsyntaktiken.
+- Synkade kursstoren mot lokala runes-tillstånd och anpassade formulär, drag-och-släpp samt dialoglogik för att fungera med det nya event-API:et.
+- Säkerställde att Svelte-check passerar utan varningar genom att justera typinferenser och event-hantering enligt Svelte 5:s riktlinjer.
+
+**Nästa steg:** Fortsätt US-M1-03 genom att bygga backend-endpointen för block (`PATCH /lessons/:id/blocks`) och introducera blocklistan i frontend med autosparningsstöd.


### PR DESCRIPTION
## Summary
- switch the course page to Svelte 5 runes mode and replace legacy reactivity with `$state`/`$effect`
- adapt event handlers, drag and drop logic, and store synchronization to the new runes APIs
- document the migration and follow-up work in `CHANGES.md`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1443c5bc083229589141488e52140